### PR TITLE
[CLN] Standardize CI to Go 1.24.x only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   GO_VERSION_STABLE: '1.24.x'
-  GO_VERSION_OLDSTABLE: '1.23.x'
 
 jobs:
   lint:
@@ -52,7 +51,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: ['1.23.x', '1.24.x']
+        go-version: ['1.24.x']
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -92,7 +91,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: ['1.23.x', '1.24.x']
+        go-version: ['1.24.x']
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
## Summary
- Remove unused `GO_VERSION_OLDSTABLE` environment variable
- Update test and build matrix strategies to use only Go 1.24.x
- Aligns CI with `go.mod` requirement of `go 1.24.0`

## Rationale
The project already requires Go 1.24.0 as the minimum version in `go.mod`. Testing against Go 1.23.x is unnecessary and wastes CI resources. This change:
- Reduces CI runtime by removing redundant test/build jobs
- Eliminates unused environment variable that was never referenced
- Ensures consistency between CI and project requirements

## Changes
- `.github/workflows/ci.yml`:
  - Removed `GO_VERSION_OLDSTABLE: '1.23.x'` (unused variable)
  - Changed test matrix from `['1.23.x', '1.24.x']` to `['1.24.x']`
  - Changed build matrix from `['1.23.x', '1.24.x']` to `['1.24.x']`

## Test Plan
- [x] CI workflow syntax is valid (YAML parsing)
- [ ] CI jobs run successfully with Go 1.24.x only
- [ ] No jobs reference the removed `GO_VERSION_OLDSTABLE` variable