### PR TITLE
docs: add initial codebase map

### DIFF
--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,130 @@
+# Architecture
+
+**Analysis Date:** 2026-03-18
+
+## Pattern Overview
+
+**Overall:** Layered Go library for native ONNX Runtime interop, with a low-level FFI core in `ort/` and model-specific convenience layers in `embeddings/`.
+
+**Key Characteristics:**
+- No-CGO design: native symbols are loaded dynamically through `purego`
+- Global runtime lifecycle managed once per process in `ort/environment.go`
+- Explicit resource ownership for tensors, sessions, memory info, and embedders
+- Higher-level embedding packages build reusable batching and post-processing on top of the raw ORT session API
+
+## Layers
+
+**FFI Runtime Layer (`ort/`):**
+- Purpose: map the ONNX Runtime C API into Go and expose safe-ish wrappers for environment, tensor, memory, and session lifecycle
+- Contains: `InitializeEnvironment`, `DestroyEnvironment`, `AdvancedSession`, `Tensor[T]`, bootstrap/download logic, OS-specific library loading
+- Depends on: `purego`, `unsafe`, native ONNX Runtime shared libraries, and generated `OrtApi` bindings
+- Used by: all example programs and all packages under `embeddings/`
+
+**Model Adapter Layer (`embeddings/*`):**
+- Purpose: hide raw tensor/session wiring behind model-specific APIs
+- Contains: `minilm.Embedder`, `splade.Embedder`, `openclip.Embedder`, session cache management, tokenizer usage, pooling/post-processing
+- Depends on: `ort/`, `pure-tokenizers`, and model-specific local artifacts
+- Used by: example programs and downstream applications that want dense, sparse, or CLIP embeddings
+
+**Utility Layer (`embeddings/internal/ortutil`):**
+- Purpose: small shared helpers for resource cleanup
+- Contains: `DestroyAll`
+- Depends on: only local interfaces and the Go standard library
+- Used by: embedding packages when tearing down grouped ORT resources
+
+**Executable/Tooling Layer (`examples/`, `tools/`, `.github/workflows/`):**
+- Purpose: provide runnable demos, generators, and CI/release automation
+- Contains: basic/inference/openclip examples, OpenCLIP export tooling, `gen_ortapi.go`, GitHub Actions workflows
+- Depends on: lower library layers plus external services such as GitHub and Hugging Face
+- Used by: maintainers, CI, and users validating real-world flows
+
+## Data Flow
+
+**Core ORT Inference Flow:**
+
+1. Caller resolves a runtime library path explicitly or via `EnsureOnnxRuntimeSharedLibrary()` in `ort/bootstrap.go`
+2. `ort.InitializeEnvironment()` loads the native library, registers function pointers, and creates a process-global ORT environment
+3. Caller creates tensors via `ort.NewTensor` / `ort.NewEmptyTensor`
+4. Caller constructs an `ort.AdvancedSession` with model path, input names, and output names
+5. `AdvancedSession.Run()` acquires session-local and global runtime locks, converts names/values into native handles, and invokes ORT
+6. Callers read tensor-backed output slices and then destroy sessions/tensors/environment in reverse order
+
+**Embedding Flow:**
+
+1. Caller initializes `ort` once for the process
+2. Embedder loads tokenizer/model metadata and validates artifact paths
+3. Inputs are tokenized or preprocessed into reusable backing buffers
+4. Package-specific session caches keyed by batch size reuse tensors and `AdvancedSession` instances
+5. Post-processing converts raw outputs into dense vectors, sparse vectors, or CLIP similarity matrices
+
+**Bootstrap/Asset Resolution Flow:**
+
+1. Bootstrap resolves cache directory and target artifact names from platform/runtime config
+2. Downloads are guarded by file/process locks
+3. Archives/files are validated for size, checksum, and path traversal
+4. Resolved local file paths are returned to the caller for normal `ort` or embedding setup
+
+**State Management:**
+- Process-global ORT state lives in package globals in `ort/environment.go`
+- Session-level mutable state lives on `AdvancedSession` and embedder caches
+- Persistent state is file-based only (user cache directories and generated artifacts)
+
+## Key Abstractions
+
+**`AdvancedSession`:**
+- Purpose: wrap an ONNX Runtime session plus fixed input/output bindings
+- Examples: `ort/session.go`, used directly by `examples/inference/main.go` and all embedding packages
+- Pattern: stateful handle wrapper with explicit `Run()` / `Destroy()`
+
+**`Tensor[T]`:**
+- Purpose: represent ORT values backed by Go slices pinned for native access
+- Examples: `ort/tensor.go`
+- Pattern: generic resource wrapper with finalizer safety net and explicit destroy semantics
+
+**`BootstrapOption` / embedding `Option`:**
+- Purpose: configure bootstrap and embedder behavior without large constructors
+- Examples: `ort/bootstrap.go`, `embeddings/minilm/embedder.go`, `embeddings/splade/embedder.go`, `embeddings/openclip/embedder.go`
+- Pattern: functional options
+
+## Entry Points
+
+**Library Entry Points:**
+- `ort/environment.go` - global runtime initialization and teardown
+- `ort/session.go` - model session creation and inference
+- `ort/tensor.go` - tensor allocation and lifecycle
+
+**Example Programs:**
+- `examples/basic/main.go` - minimal runtime initialization example
+- `examples/inference/main.go` - end-to-end single-model inference flow driven by env vars
+- `examples/openclip/main.go` - OpenCLIP text/image embedding demo with manifest-backed fixtures
+
+**Tooling:**
+- `tools/gen_ortapi.go` - regenerates `ort/ortapi_generated.go` from ONNX Runtime headers
+
+## Error Handling
+
+**Strategy:** return Go `error` values aggressively, validate inputs early, and use deferred cleanup to keep native handles from leaking.
+
+**Patterns:**
+- Wrap lower-level failures with `fmt.Errorf(...: %w)`
+- Translate ORT `OrtStatus` handles into Go strings via helper functions in `ort/environment.go`
+- Use `errors.Join` when cleanup steps can fail independently
+- Treat nil receivers as safe no-ops for most `Destroy()` methods
+
+## Cross-Cutting Concerns
+
+**Concurrency:**
+- `ort/environment.go` defines a lock hierarchy spanning global runtime state, session runs, and tensor lifetimes
+- Several tests in `ort/session_test.go` and `ort/environment_test.go` exist specifically to protect these invariants
+
+**Memory Management:**
+- The code pins Go slice backing arrays while native ORT uses them (`ort/tensor.go`)
+- Finalizers are present as leak backstops, but the design still expects explicit `Destroy()` calls
+
+**Security and Integrity:**
+- Bootstrap code validates checksums, path traversal, redirect safety, and download size limits in both `ort/bootstrap.go` and `embeddings/openclip/bootstrap.go`
+
+---
+
+*Architecture analysis: 2026-03-18*
+*Update when major patterns change*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,105 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-03-18
+
+## Tech Debt
+
+**Generated ORT API binding pipeline:**
+- Issue: `tools/gen_ortapi.go` uses regex parsing of upstream headers instead of a real C parser
+- Why: simple generation was fast to bootstrap
+- Impact: upstream header format changes could silently break `ort/ortapi_generated.go` generation or field ordering
+- Fix approach: replace the parser with a proper C AST approach or add stronger structural validation around generator output
+
+**Stale maintainer guidance in `CLAUDE.md`:**
+- Issue: the file still references `main2.go` as the main implementation entry point, but that file does not exist in the current tree
+- Why: documentation drift as the repo evolved
+- Impact: maintainers or automation may follow outdated guidance
+- Fix approach: update `CLAUDE.md` to match the current `examples/`-based layout and active packages
+
+**Partially implemented wrapper types:**
+- Issue: `ort/types.go` still contains placeholder `Status.GetErrorCode()` and `Status.GetErrorMessage()` implementations
+- Why: the public API surface was sketched before all wrappers were wired to real ORT calls
+- Impact: contributors can mistake these types for production-ready abstractions
+- Fix approach: either finish the implementation or clearly de-emphasize/remove unused wrapper surfaces
+
+## Known Bugs
+
+**Incorrect usage docs are possible around version support:**
+- Symptoms: docs and code can drift between `DefaultOnnxRuntimeVersion`, CI-pinned runtime versions, and README examples
+- Trigger: bumping runtime versions in one place but not the others
+- Workaround: treat `ort/bootstrap.go`, `.github/workflows/ci.yml`, and `README.md` as a synchronized set during upgrades
+- Root cause: multiple version pins live in different files for different purposes
+
+## Security Considerations
+
+**Native binary bootstrap paths must stay hardened:**
+- Risk: relaxing checksum, redirect, or path traversal checks in `ort/bootstrap.go` or `embeddings/openclip/bootstrap.go` would expose consumers to malicious binary/model downloads
+- Current mitigation: checksum validation, redirect policy enforcement, size limits, path sanitization, and lock-guarded extraction
+- Recommendations: preserve these checks during refactors and add tests first when changing bootstrap behavior
+
+**Credential-bearing env vars are handled by runtime/test code:**
+- Risk: `GITHUB_TOKEN`, `GH_TOKEN`, `HF_TOKEN`, and release secrets could be leaked through unsafe logging or insecure redirects
+- Current mitigation: token use is limited and OpenCLIP bootstrap rejects insecure token-bearing base URLs
+- Recommendations: keep logs free of raw env values and treat any new download URL override as security-sensitive
+
+## Performance Bottlenecks
+
+**Session creation remains expensive compared with warm reuse:**
+- Problem: embedder packages build LRU caches to avoid repeatedly creating ORT sessions per batch size
+- Measurement: the existence of dedicated benchmarks in `ort/session_benchmark_test.go` and `embeddings/splade/benchmark_test.go` indicates session setup cost is material
+- Cause: native session creation and tensor wiring are heavier than reuse
+- Improvement path: preserve cache hit paths and benchmark any refactor that touches session lifecycle
+
+**Bootstrap and integration flows download large artifacts:**
+- Problem: real-model tests and bootstrap code move hundreds of MB of runtime/model data
+- Measurement: CI allocates dedicated cache keys and download steps in `.github/workflows/ci.yml`
+- Cause: native runtime archives and model bundles are large by nature
+- Improvement path: keep cache keys stable, avoid redundant downloads, and be careful with checksum/version churn
+
+## Fragile Areas
+
+**Global ORT lifecycle and lock ordering:**
+- Why fragile: `ort/environment.go`, `ort/session.go`, and `ort/tensor.go` coordinate multiple locks and native handles with a strict ordering contract
+- Common failures: deadlocks, use-after-destroy bugs, or release calls after environment teardown
+- Safe modification: change these paths only with concurrency tests running and keep lock-order comments accurate
+- Test coverage: strong relative coverage in `ort/environment_test.go` and `ort/session_test.go`, but still high-risk code
+
+**Embedder tensor/session cache internals:**
+- Why fragile: `embeddings/minilm`, `embeddings/splade`, and `embeddings/openclip` reuse backing slices and tensor handles across runs
+- Common failures: accidental slice reallocation, stale cache entries, or broken LRU eviction
+- Safe modification: preserve buffer ownership assumptions and run integration plus cache-behavior tests after changes
+- Test coverage: good package-local tests, but behavior still depends on real model contracts
+
+## Scaling Limits
+
+**Single-process global runtime model:**
+- Current capacity: one process-global ORT environment shared across sessions
+- Limit: alternative multi-runtime or per-tenant isolation models are not represented in the current architecture
+- Symptoms at limit: awkward lifecycle coordination for complex host applications
+- Scaling path: introduce a more explicit runtime/handle ownership model only with careful API redesign
+
+## Dependencies at Risk
+
+**Pure FFI dependence on ONNX Runtime ABI stability:**
+- Risk: upstream ABI or packaging changes can break symbol registration, archive naming, or runtime expectations
+- Impact: bootstrap, initialization, or session creation failures across supported platforms
+- Migration plan: keep `internal/c_api/` snapshots, generator output, CI runtime versions, and bootstrap rules aligned when upgrading
+
+## Test Coverage Gaps
+
+**Python tooling is effectively outside the Go test matrix:**
+- What's not tested: `tools/openclip_export_onnx.py`, `tools/openclip_generate_golden.py`, and `tools/splade_generate_golden.py`
+- Risk: export or dataset-generation regressions may not be caught until maintainers run them manually
+- Priority: medium
+- Difficulty to test: requires Python environment setup, heavyweight ML dependencies, and artifact generation time
+
+**Release workflow behavior is mostly validated indirectly:**
+- What's not tested: end-to-end `.github/workflows/release.yml` behavior against real R2 credentials and signed artifact publishing
+- Risk: release-only failures can slip through normal PR CI
+- Priority: medium
+- Difficulty to test: depends on secrets, tag pushes, and external infrastructure
+
+---
+
+*Concerns audit: 2026-03-18*
+*Update as issues are fixed or new ones are discovered*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,116 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-03-18
+
+## Naming Patterns
+
+**Files:**
+- lower_snake_case for implementation files: `environment.go`, `bootstrap_lock_unix.go`, `golden_dataset_parity_test.go`
+- `*_test.go` for all test files, often with specialized suffixes like `*_integration_test.go` or `*_benchmark_test.go`
+- generated code is named explicitly with `_generated`: `ort/ortapi_generated.go`
+
+**Functions:**
+- Exported APIs use Go-standard PascalCase: `InitializeEnvironment`, `EnsureDefaultAssets`, `WithSequenceLength`
+- Unexported helpers use lowerCamelCase: `resolveRuntimeArtifact`, `validateFilePath`, `setupORTTestEnvironment`
+- Functional option constructors consistently start with `With` / `Without`
+
+**Variables:**
+- lowerCamelCase for locals and fields
+- package-level constants are mostly PascalCase when exported and lowerCamelCase when internal
+- all-caps names are reserved for compatibility constants or env-oriented identifiers such as `ORT_API_VERSION`
+
+**Types:**
+- PascalCase for structs, interfaces, and enums: `AdvancedSession`, `MemoryInfo`, `PoolingStrategy`
+- Package names stay short and lowercase: `ort`, `minilm`, `splade`, `openclip`
+
+## Code Style
+
+**Formatting:**
+- `gofmt` and `goimports` are the formatting source of truth (`.golangci.yml`, `Makefile`)
+- Standard Go formatting conventions apply: tabs, grouped imports, no manual alignment
+- Error strings are generally lowercase and sentence-fragment style
+
+**Linting:**
+- `go vet`, `golangci-lint`, and `gosec` are the main static checks
+- `precommit` in `Makefile` mirrors CI blockers, with opt-out env vars for local workflows
+- `.golangci.yml` keeps the rule set small and targeted instead of enabling everything
+
+## Import Organization
+
+**Order:**
+1. Go standard library imports
+2. Repository-local imports such as `github.com/amikos-tech/pure-onnx/ort`
+3. Third-party imports such as `github.com/ebitengine/purego`
+
+**Grouping:**
+- One blank line between import groups
+- No path aliases beyond short clarity-driven aliases like `tokenizers`
+- Side-effect imports are only used when required, for example image codecs in `examples/openclip/main.go`
+
+**Path Aliases:**
+- None; imports use full module paths
+
+## Error Handling
+
+**Patterns:**
+- Validate aggressively at function entry and return early on bad inputs
+- Wrap underlying failures with `fmt.Errorf(...: %w)`
+- Join cleanup failures with `errors.Join` where multiple destroy steps can fail
+- Native-handle wrappers usually treat nil receivers as safe no-ops on `Destroy()`
+
+**Error Types:**
+- Most code returns plain `error` rather than custom error structs
+- A few package-private sentinel or wrapper types exist where retry/permanence matters, such as `permanentBootstrapError` in `ort/bootstrap.go`
+- Tests assert on message content frequently, so wording changes can be user-visible
+
+## Logging
+
+**Framework:**
+- Standard library `log` package only
+
+**Patterns:**
+- Library code logs sparingly, mainly for warnings or bootstrap path visibility
+- Examples use `log.Fatal` / `log.Printf` for CLI-style behavior
+- There is no structured logging abstraction
+
+## Comments
+
+**When to Comment:**
+- Explain FFI safety assumptions, lock ordering, and lifetime rules
+- Document why `unsafe` usage is acceptable in specific places
+- Keep obvious code uncommented
+
+**Doc Comments:**
+- Exported types, constants, and functions are usually documented
+- Internal helpers receive comments when concurrency, lifecycle, or security behavior is non-obvious
+
+**Security/Lint Markers:**
+- `#nosec` annotations are used narrowly to justify intentional `unsafe` pointer conversions or checksum-like constants
+
+## Function Design
+
+**Size:**
+- Public APIs tend to be moderate-sized with early validation and deferred cleanup
+- The longest functions are concentrated in bootstrap/download code and embedder setup paths
+
+**Parameters:**
+- Constructors prefer explicit required parameters plus functional options
+- Helpers avoid large configuration structs at call sites unless state needs to persist
+
+**Return Values:**
+- APIs nearly always return `(value, error)` or `error`
+- Cleanup methods return `error` rather than panicking
+
+## Module Design
+
+**Exports:**
+- Packages expose focused public APIs and keep helpers unexported
+- `internal/` is used only where cross-package reuse should remain private
+
+**Generated Code:**
+- `ort/ortapi_generated.go` is treated as generated output; changes should come from `tools/gen_ortapi.go` and header inputs, not hand edits
+
+---
+
+*Convention analysis: 2026-03-18*
+*Update when patterns change*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,100 @@
+# External Integrations
+
+**Analysis Date:** 2026-03-18
+
+## APIs & External Services
+
+**ONNX Runtime Releases:**
+- Microsoft GitHub releases - primary source for native runtime bootstrap in `ort/bootstrap.go`
+  - SDK/Client: standard `net/http`
+  - Auth: optional `GITHUB_TOKEN` / `GH_TOKEN` for GitHub API rate-limit headroom
+  - Endpoints used: release metadata under `api.github.com/repos/microsoft/onnxruntime/releases/tags/*` and release asset downloads under `github.com/microsoft/onnxruntime/releases/download/*`
+
+**Model Hosting:**
+- Hugging Face Hub - source for OpenCLIP assets and several test fixtures
+  - Integration method: direct HTTPS downloads via `net/http` in `embeddings/openclip/bootstrap.go` and test helpers in `embeddings/*`
+  - Auth: optional `HF_TOKEN` bearer token for gated/private assets
+  - Artifacts used: `text_model.onnx`, `vision_model.onnx`, `tokenizer.json`, `preprocessor_config.json`, hosted parity datasets
+
+**Release Distribution:**
+- Cloudflare R2 - release artifact storage configured in `.github/workflows/release.yml`
+  - SDK/Client: AWS CLI over S3-compatible API
+  - Auth: `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ENDPOINT`
+  - Objects used: release archives, `SHA256SUMS`, `latest.json`, optional `releases.json`
+
+## Data Storage
+
+**Databases:**
+- None - the library is stateless and does not persist application data to a database.
+
+**File Storage:**
+- Local filesystem caches under the user cache dir - bootstrap artifacts for ONNX Runtime and OpenCLIP.
+  - ORT cache: default user cache under `onnx-purego/onnxruntime` from `ort/bootstrap.go`
+  - OpenCLIP cache: default user cache under `onnx-purego/openclip` from `embeddings/openclip/bootstrap.go`
+
+**Caching:**
+- In-process LRU caches for batch-size-specific sessions in `embeddings/minilm/embedder.go`, `embeddings/splade/embedder.go`, and `embeddings/openclip/embedder.go`
+- GitHub Actions cache for downloaded model assets in `.github/workflows/ci.yml`
+
+## Authentication & Identity
+
+**Auth Provider:**
+- None for library consumers - there is no user/session auth inside the Go packages.
+
+**Token-Based Integrations:**
+- GitHub API tokens for bootstrap metadata lookup and CI
+- Hugging Face token for model/dataset downloads and optional private artifact access
+- Cloudflare and R2 credentials only inside release automation
+
+## Monitoring & Observability
+
+**Error Tracking:**
+- None integrated into the library itself; errors are returned directly to callers.
+
+**Analytics:**
+- None
+
+**Logs:**
+- Standard output/error only
+  - Library code logs a small number of warnings via `log.Printf` in bootstrap and environment initialization paths
+  - CI logs come from GitHub Actions workflow steps
+
+## CI/CD & Deployment
+
+**Hosting:**
+- GitHub repository plus GitHub Actions for CI
+- Release artifacts mirrored to Cloudflare R2 and GitHub Releases
+
+**CI Pipeline:**
+- GitHub Actions workflows in `.github/workflows/`
+  - `ci.yml` - lint, cross-platform tests, targeted race tests, real-model integration tests
+  - `release.yml` - build, sign, verify, and publish release bundles
+  - `claude.yml` and `claude-code-review.yml` - repo automation around Claude Code
+  - `dependabot.yml` - dependency update automation
+
+## Environment Configuration
+
+**Development:**
+- No `.env` contract; configuration is done through exported environment variables and CLI tooling.
+- Developers commonly need `ONNXRUNTIME_LIB_PATH` for explicit local runtime setup.
+- Network access is optional for normal unit tests, but required for bootstrap/download-based flows.
+
+**Staging:**
+- No distinct staging environment exists in the codebase.
+
+**Production:**
+- Consumer applications are expected to provide the correct ONNX Runtime shared library or rely on the bootstrapper.
+- Release publishing requires GitHub Secrets and optional Cloudflare cache-purge variables defined in the repository settings.
+
+## Webhooks & Callbacks
+
+**Incoming:**
+- None in the application/library runtime.
+
+**Outgoing:**
+- None in the library runtime beyond direct HTTPS downloads for bootstrapping and test asset retrieval.
+
+---
+
+*Integration audit: 2026-03-18*
+*Update when adding or removing external services*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,79 @@
+# Technology Stack
+
+**Analysis Date:** 2026-03-18
+
+## Languages
+
+**Primary:**
+- Go 1.24.0 - All library code, examples, and tests live under `ort/`, `embeddings/`, `examples/`, and `tools/gen_ortapi.go`.
+
+**Secondary:**
+- Python 3.10+ - Export and golden-data tooling in `tools/openclip_export_onnx.py`, `tools/openclip_generate_golden.py`, and `tools/splade_generate_golden.py`.
+- Shell/Make - Local automation and CI entry points in `Makefile`, `.githooks/pre-commit`, and `.github/workflows/*.yml`.
+- C headers (reference only) - ONNX Runtime API definitions in `internal/c_api/onnxruntime_c_api.h` and `internal/c_api/ort_apis.h`; these are not compiled directly.
+
+## Runtime
+
+**Environment:**
+- Go 1.24.x for normal development and CI (`go.mod`, `.github/workflows/ci.yml`).
+- Patched Go 1.25.8+auto only for vulnerability scanning via `govulncheck` (`Makefile`, CI env `GO_VULNCHECK_TOOLCHAIN`).
+- Native ONNX Runtime shared libraries are loaded dynamically at runtime through `purego`, so consumers still need a platform-specific `.so`, `.dylib`, or `.dll`.
+
+**Package Manager:**
+- Go modules
+- Lockfile: `go.sum` present
+
+## Frameworks
+
+**Core:**
+- `github.com/ebitengine/purego` v0.10.0 - CGO-free dynamic library loading and symbol binding in `ort/environment.go`, `ort/library_unix.go`, and `ort/library_windows.go`.
+- Microsoft ONNX Runtime C API v22 - exposed through generated bindings in `ort/ortapi_generated.go` and constants in `ort/constants.go`.
+- `github.com/amikos-tech/pure-tokenizers` v0.1.4 - tokenizer support for `embeddings/minilm`, `embeddings/splade`, and `embeddings/openclip`.
+
+**Testing:**
+- Go `testing` package - unit, integration, race, and benchmark coverage across `ort/` and `embeddings/`.
+- `github.com/stretchr/testify` v1.11.1 - supplemental assertions in parts of the test suite.
+
+**Build/Dev:**
+- `gofmt`, `goimports`, `go vet`, `go test` - standard local verification, wired through `Makefile`.
+- `golangci-lint` v2.8.0 and `gosec` v2.23.0 - optional but expected pre-commit and CI tooling.
+
+## Key Dependencies
+
+**Critical:**
+- `github.com/ebitengine/purego` v0.10.0 - the entire no-CGO binding strategy depends on it.
+- `github.com/amikos-tech/pure-tokenizers` v0.1.4 - used by all higher-level embedding packages for tokenizer loading and preprocessing.
+- `golang.org/x/sys` v0.41.0 - OS-specific helpers for file locking and native runtime interactions.
+
+**Infrastructure:**
+- `github.com/Masterminds/semver/v3` v3.4.0 - version parsing in runtime/bootstrap flows.
+- Python packages `torch`, `transformers`, `huggingface_hub`, `numpy`, and `onnxruntime==1.23.1` - used only by OpenCLIP export tooling in `tools/requirements-openclip.txt`.
+
+## Configuration
+
+**Environment:**
+- Runtime library resolution: `ONNXRUNTIME_LIB_PATH`, `ONNXRUNTIME_VERSION`, `ONNXRUNTIME_CACHE_DIR`, `ONNXRUNTIME_DISABLE_DOWNLOAD`, `ONNXRUNTIME_SKIP_VERSION_CHECK`.
+- GitHub-backed bootstrap and checksum lookup: `GITHUB_TOKEN` / `GH_TOKEN`.
+- Hugging Face-backed asset downloads: `HF_TOKEN`, `ONNXRUNTIME_OPENCLIP_CACHE_DIR`.
+- Test-specific overrides are documented in `TESTING.md` and consumed throughout `ort/*_test.go` and `embeddings/*_test.go`.
+
+**Build:**
+- `Makefile` - main task runner for build, test, lint, release, and pre-commit flows.
+- `.golangci.yml` - linter and formatter configuration.
+- `.github/workflows/ci.yml` and `.github/workflows/release.yml` - CI, integration, and release pipelines.
+
+## Platform Requirements
+
+**Development:**
+- macOS, Linux, or Windows with Go 1.24+.
+- Either an explicit ONNX Runtime shared library or network access for bootstrap download/caching.
+- Python is optional unless working on export or golden-dataset tooling in `tools/`.
+
+**Production:**
+- Intended as an embeddable Go library plus example binaries built from `examples/basic` and `examples/inference`.
+- Target platforms currently mirror ONNX Runtime artifact handling in `ort/bootstrap.go`: Linux amd64/arm64, macOS amd64/arm64, and Windows amd64/arm64.
+
+---
+
+*Stack analysis: 2026-03-18*
+*Update after major dependency or toolchain changes*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,150 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-03-18
+
+## Directory Layout
+
+```text
+onnx-purego/
+├── .github/workflows/        # CI, review, and release automation
+├── .githooks/                # Repo-managed git hooks
+├── .planning/codebase/       # Generated codebase map documents
+├── docs/                     # Runbooks and release/export documentation
+├── embeddings/               # High-level embedding packages on top of ort
+│   ├── internal/ortutil/     # Shared cleanup helper
+│   ├── minilm/               # Dense sentence embedding adapter
+│   ├── openclip/             # Text + image embedding adapter and asset bootstrap
+│   └── splade/               # Sparse embedding adapter
+├── examples/                 # Runnable sample programs
+│   ├── basic/                # Minimal initialization example
+│   ├── experimental/         # Unsafe/manual experiment code paths
+│   ├── inference/            # End-to-end inference example
+│   └── openclip/             # OpenCLIP example plus committed fixture assets
+├── internal/c_api/           # ONNX Runtime header snapshots for reference/generation
+├── ort/                      # Low-level runtime bindings and wrappers
+├── tools/                    # Generators and Python-based model tooling
+├── Makefile                  # Primary task runner
+├── README.md                 # User-facing package overview
+└── TESTING.md                # Test setup and matrix documentation
+```
+
+## Directory Purposes
+
+**`ort/`:**
+- Purpose: core ONNX Runtime binding and lifecycle package
+- Contains: environment/session/tensor/memory code, bootstrap/download logic, generated API bindings, platform-specific library loaders
+- Key files: `ort/environment.go`, `ort/session.go`, `ort/tensor.go`, `ort/bootstrap.go`, `ort/ortapi_generated.go`
+- Subdirectories: none; package is flat with `_unix.go` and `_windows.go` file suffixes for platform-specific behavior
+
+**`embeddings/`:**
+- Purpose: higher-level model adapters that turn raw ORT sessions into convenient embedding APIs
+- Contains: three public subpackages plus `internal/ortutil`
+- Key files: `embeddings/minilm/embedder.go`, `embeddings/splade/embedder.go`, `embeddings/openclip/embedder.go`, `embeddings/openclip/bootstrap.go`
+- Subdirectories: `minilm/`, `splade/`, `openclip/`, `internal/ortutil/`
+
+**`examples/`:**
+- Purpose: runnable demonstrations for common usage patterns
+- Contains: `main.go` programs, example READMEs, and OpenCLIP sample assets
+- Key files: `examples/basic/main.go`, `examples/inference/main.go`, `examples/openclip/main.go`
+- Subdirectories: `openclip/assets/` contains committed PNG fixtures and `manifest.jsonl`
+
+**`tools/`:**
+- Purpose: repository maintenance and offline artifact tooling
+- Contains: header/code generators plus Python scripts for OpenCLIP export and golden dataset generation
+- Key files: `tools/gen_ortapi.go`, `tools/openclip_export_onnx.py`, `tools/openclip_generate_golden.py`, `tools/splade_generate_golden.py`
+- Subdirectories: none
+
+**`docs/`:**
+- Purpose: maintainer-facing runbooks
+- Contains: release and export documentation
+- Key files: `docs/openclip-export.md`, `docs/releases.md`
+- Subdirectories: none
+
+## Key File Locations
+
+**Entry Points:**
+- `examples/basic/main.go` - minimal library smoke test
+- `examples/inference/main.go` - env-driven inference example
+- `examples/openclip/main.go` - OpenCLIP demo application
+- `tools/gen_ortapi.go` - generator entry point for `ort/ortapi_generated.go`
+
+**Configuration:**
+- `go.mod` / `go.sum` - module and dependency state
+- `Makefile` - local build/test/release commands
+- `.golangci.yml` - lint/formatter configuration
+- `.github/workflows/ci.yml` - CI matrix and integration setup
+- `.gitignore` - generated artifact and local cache rules
+
+**Core Logic:**
+- `ort/` - raw bindings and runtime bootstrap
+- `embeddings/minilm/` - dense text embedding flow
+- `embeddings/splade/` - sparse text embedding flow
+- `embeddings/openclip/` - multimodal embedding flow and default asset bootstrap
+
+**Testing:**
+- `ort/*_test.go` - the deepest unit/race/integration coverage
+- `embeddings/*/*_test.go` - package-specific behavior, integration, parity, and benchmark coverage
+- `examples/openclip/main_test.go` - example-level validation
+
+**Documentation:**
+- `README.md` - main package and examples overview
+- `TESTING.md` - full test environment documentation
+- `docs/*.md` - specialized maintainer runbooks
+
+## Naming Conventions
+
+**Files:**
+- lower_snake_case for Go source files: `shape_parse.go`, `session_benchmark_test.go`
+- `*_test.go` for tests
+- generated files are called out explicitly: `ort/ortapi_generated.go`
+
+**Directories:**
+- lowercase package names: `ort`, `minilm`, `openclip`, `splade`
+- nested `internal/` only where visibility should be restricted (`embeddings/internal/ortutil`)
+
+**Special Patterns:**
+- OS-specific implementations use suffixes such as `_unix.go` and `_windows.go`
+- examples consistently use `main.go`
+- docs and repo control files are uppercase where conventional: `README.md`, `TESTING.md`, `CLAUDE.md`
+
+## Where to Add New Code
+
+**New ORT capability:**
+- Primary code: `ort/`
+- Tests: matching `ort/*_test.go`
+- Reference header updates: `internal/c_api/` plus `tools/gen_ortapi.go` if API shape changes
+
+**New embedding model adapter:**
+- Primary code: `embeddings/<model>/`
+- Shared cleanup helpers: `embeddings/internal/ortutil/` only if reused across packages
+- Tests: colocated `*_test.go`, `*_integration_test.go`, and optional benchmarks
+
+**New example:**
+- Implementation: `examples/<name>/main.go`
+- Docs: `examples/<name>/README.md` when setup is non-trivial
+
+**New tooling/runbook:**
+- Automation/scripts: `tools/`
+- Human-facing docs: `docs/`
+
+## Special Directories
+
+**`internal/c_api/`:**
+- Purpose: checked-in ONNX Runtime headers and related reference material
+- Source: upstream ONNX Runtime C API snapshots
+- Committed: yes
+
+**`examples/openclip/assets/`:**
+- Purpose: committed demo fixtures for the OpenCLIP example
+- Source: curated PNG assets plus `manifest.jsonl`
+- Committed: yes
+
+**Generated/ignored local dirs (`build/`, `third_party/`, `.cache/`):**
+- Purpose: downloaded artifacts, temporary builds, local caches
+- Source: bootstrap flows, manual tooling, or local development
+- Committed: no, ignored by `.gitignore`
+
+---
+
+*Structure analysis: 2026-03-18*
+*Update when directory structure changes*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,169 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-03-18
+
+## Test Framework
+
+**Runner:**
+- Go `testing` package
+- No custom test harness; package-local helpers live in normal `*_test.go` files
+
+**Assertion Library:**
+- Primarily `testing` with `t.Fatalf`, `t.Errorf`, `t.Skip`, and `t.Helper`
+- `testify` is available in `go.mod` for richer assertions where useful
+
+**Run Commands:**
+```bash
+go test ./...                              # Full package test run
+go test -v ./ort/...                       # Core ORT package with verbose output
+go test -v ./embeddings/minilm             # One embedding package
+go test -race ./ort -run 'TestAdvancedSessionRunConcurrent'  # Targeted race subset
+go test -run '^$' -bench=. -benchmem ./ort/...               # Benchmarks
+make test                                  # Repo-level test target
+```
+
+## Test File Organization
+
+**Location:**
+- Tests are colocated with implementation files in each package
+- There is no separate top-level `tests/` directory
+
+**Naming:**
+- Unit tests: `*_test.go`
+- Integration tests: `*_integration_test.go`
+- Benchmarks: `*_benchmark_test.go` or benchmark functions inside standard test files
+
+**Structure:**
+```text
+ort/
+  environment.go
+  environment_test.go
+  session.go
+  session_test.go
+  session_benchmark_test.go
+embeddings/minilm/
+  embedder.go
+  embedder_test.go
+  embedder_integration_test.go
+```
+
+## Test Structure
+
+**Suite Organization:**
+```go
+func TestResolveRuntimeArtifact(t *testing.T) {
+    tests := []struct {
+        name string
+        // inputs and expectations...
+    }{ /* ... */ }
+
+    for _, tc := range tests {
+        t.Run(tc.name, func(t *testing.T) {
+            // arrange
+            // act
+            // assert
+        })
+    }
+}
+```
+
+**Patterns:**
+- Table-driven tests are common for validation and platform matrices
+- `t.TempDir()` is the default for filesystem-heavy tests
+- Helpers such as `setupORTTestEnvironment` centralize ORT init/cleanup in integration suites
+- Concurrency tests use `sync.WaitGroup`, channels, and atomic counters rather than custom frameworks
+
+## Mocking
+
+**Framework:**
+- Mostly hand-rolled fakes and standard-library test servers
+- `httptest.Server` is used for download/bootstrap scenarios
+
+**Patterns:**
+- Mock HTTP sources by spinning up local servers in tests like `ort/bootstrap_test.go`
+- Override env vars to steer download URLs, cache dirs, and runtime library paths
+- Use temp files and synthetic archives instead of mocking filesystem packages
+
+**What to Mock:**
+- External downloads and HTTP status handling
+- Local cache directories and archive contents
+- Environment-variable-driven configuration
+
+**What NOT to Mock:**
+- Core in-memory tensor/session logic when unit tests can run without a real runtime
+- Real ORT integration paths once `ONNXRUNTIME_LIB_PATH` is available
+
+## Fixtures and Factories
+
+**Test Data:**
+- OpenCLIP ships committed image fixtures in `examples/openclip/assets/`
+- Integration tests download or reuse cached model artifacts under a configurable cache root
+- Golden regression datasets for SPLADE and OpenCLIP are validated against hosted JSONL assets
+
+**Location:**
+- Small helpers and factories stay beside the tests (`embeddings/openclip/test_helpers_test.go`, `embeddings/splade/test_helpers_test.go`)
+- Larger fixture assets live under `examples/openclip/assets/` or user cache directories during test runs
+
+## Coverage
+
+**Requirements:**
+- No explicit numeric coverage gate is enforced in the repo
+- CI still uploads coverage from the main test matrix to Codecov
+
+**Configuration:**
+- Coverage is generated with `go test -coverprofile=coverage.out`
+- Some race coverage is intentionally partial because purego/unsafe interop conflicts with full `-race` + checkptr usage
+
+**View Coverage:**
+```bash
+make test-coverage
+open coverage.html
+```
+
+## Test Types
+
+**Unit Tests:**
+- Heavy in `ort/` for validation, shape parsing, memory lifecycle, and bootstrap security logic
+- Usually avoid requiring a real ONNX Runtime library
+
+**Integration Tests:**
+- Enabled when `ONNXRUNTIME_LIB_PATH` is set or when package-specific bootstrap logic can fetch assets
+- Cover end-to-end model execution in `ort/`, `embeddings/minilm`, `embeddings/splade`, and `embeddings/openclip`
+
+**Benchmark Tests:**
+- Concentrated in `ort/session_benchmark_test.go` and `embeddings/splade/benchmark_test.go`
+- Focus on warm-run throughput and session creation overhead
+
+## Common Patterns
+
+**Async/Concurrency Testing:**
+```go
+var wg sync.WaitGroup
+for i := 0; i < workers; i++ {
+    wg.Add(1)
+    go func() {
+        defer wg.Done()
+        // invoke session/bootstrap path
+    }()
+}
+wg.Wait()
+```
+
+**Error Testing:**
+```go
+if err == nil {
+    t.Fatalf("expected error, got nil")
+}
+if !strings.Contains(err.Error(), "checksum") {
+    t.Fatalf("unexpected error: %v", err)
+}
+```
+
+**Snapshot Testing:**
+- Not used
+- Golden/parity testing is value-based rather than textual snapshot-based
+
+---
+
+*Testing analysis: 2026-03-18*
+*Update when test patterns change*


### PR DESCRIPTION
## Summary
- add the initial GSD codebase map under `.planning/codebase`
- document the current stack, architecture, structure, conventions, testing, integrations, and concerns for the repo
- capture the brownfield baseline needed for follow-on GSD project initialization and planning

## Verification
- verified all 7 codebase map documents were created and non-empty
- checked line counts for `.planning/codebase/*.md`
- ran the workflow secret-pattern scan against `.planning/codebase/*.md`