### PR TITLE
docs: update TESTING.md Go baseline to 1.25.x

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -249,11 +249,11 @@ tests remain self-contained after publishing to `tazarov/pure-onnx`.
 ### GitHub Actions
 
 The CI pipeline runs tests in multiple configurations:
-- **Unit Tests**: Run on all platforms (Linux, macOS, Windows) with Go 1.24.x
+- **Unit Tests**: Run on all platforms (Linux, macOS, Windows) with Go 1.25.x
 - **Integration Tests (matrix job)**: Skipped in the cross-platform matrix (no ONNX Runtime library preinstalled)
 - **Real-model Integration Job**: Linux job downloads ONNX Runtime, runs all-MiniLM integration + memory stability tests, runs SPLADE integration and hosted parity, runs OpenCLIP integration and hosted parity, and runs all-MiniLM benchmarks
 - **Race Detection**: Partially disabled due to checkptr incompatibility with purego FFI
-- **Vulnerability Check**: Runs `make vulncheck` with a patched Go baseline (`go1.25.8+auto`)
+- **Vulnerability Check**: Runs `make vulncheck` with a patched Go baseline (`go1.25.12+auto`)
 
 ### Local Pre-commit Checks
 


### PR DESCRIPTION
## Summary

Updates the last stale Go baseline references in `TESTING.md` to match the Go 1.25.x baseline adopted in #93.

- `Go 1.24.x` → `Go 1.25.x` (unit test matrix description)
- `go1.25.8+auto` → `go1.25.12+auto` (vulncheck toolchain, bumped in #93 to clear stdlib CVEs GO-2026-5856 / GO-2026-5039)

This closes the final acceptance-criteria item on #80 ("Documentation/README references to Go baseline are updated if present"); all other criteria were satisfied by the #93 merge.

## Notes
- `.planning/codebase/STACK.md` also references Go 1.24 but is a generated GSD codebase map, not project documentation — left out of scope.

Closes #80