### PR TITLE
fix: remove unnecessary unsafe.Pointer round-trip in Windows getSymbol

### DIFF
--- a/ort/library_windows.go
+++ b/ort/library_windows.go
@@ -3,8 +3,6 @@
 package ort
 
 import (
-	"unsafe"
-
 	"golang.org/x/sys/windows"
 )
 
@@ -17,11 +15,8 @@ func loadLibrary(path string) (uintptr, error) {
 }
 
 func getSymbol(handle uintptr, symbol string) (uintptr, error) {
-	proc, err := windows.GetProcAddress(windows.Handle(handle), symbol)
-	if err != nil {
-		return 0, err
-	}
-	return uintptr(unsafe.Pointer(proc)), nil
+	// GetProcAddress already returns a uintptr; no unsafe.Pointer round-trip needed.
+	return windows.GetProcAddress(windows.Handle(handle), symbol)
 }
 
 func closeLibrary(handle uintptr) error {


### PR DESCRIPTION
## Summary
- `windows.GetProcAddress` already returns `uintptr`, not `*byte` — the intermediate `uintptr(unsafe.Pointer(proc))` round-trip was a no-op
- `go vet` flags this exact pattern as a possible misuse of `unsafe.Pointer`; the fix removes the warning without changing behavior

## Notes
The linked issue's proposed fix assumed `GetProcAddress` returns `*byte`; in the current `golang.org/x/sys` version it already returns `uintptr`, so the actual fix is simpler than described — just return the value directly.

No new test added: `getSymbol` has no existing unit test on either platform (Windows or Unix) since exercising it meaningfully requires a real loaded library with a resolvable symbol; it's covered by the existing Windows CI build + integration tests.

Closes #22

## Test plan
- [x] `gofmt -l` clean
- [x] `GOOS=windows GOARCH=amd64 go build ./...` succeeds
- [x] `GOOS=windows GOARCH=amd64 go vet ./ort/...` no longer flags `library_windows.go:24` (confirmed the pre-fix code was exactly this warning; 3 other pre-existing warnings elsewhere are untouched)