### PR TITLE
fix(ci): move secret check out of job-level if in claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,20 +12,22 @@ on:
 
 jobs:
   claude-review:
-    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork == false && secrets.CLAUDE_CODE_OAUTH_TOKEN != ''
+    if: github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.fork == false
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+    env:
+      HAS_CLAUDE_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN != '' }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -34,6 +36,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        if: env.HAS_CLAUDE_TOKEN == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary
- `jobs.claude-review.if` referenced `secrets.CLAUDE_CODE_OAUTH_TOKEN`, but the `secrets` context isn't available in job-level `if` (only `github`, `needs`, `vars`, `inputs` are). `actionlint` confirms this: `context "secrets" is not allowed here`.
- This invalid expression made the entire workflow file fail GitHub's static validation, which runs on every push regardless of the file's own triggers — that's why the workflow had ~199 consecutive failed runs with zero jobs, even on plain pushes to `main` that a `pull_request`-only workflow should never touch.
- Fix: compute `HAS_CLAUDE_TOKEN` in the job's `env:` block (secrets are readable there), then gate the review step on `env.HAS_CLAUDE_TOKEN == 'true'` (env context is valid in step-level `if`).

## Test plan
- [x] `actionlint .github/workflows/claude-code-review.yml` passes clean (previously failed with the context error)
- [x] `yq eval .` confirms valid YAML
- [ ] Confirm on this PR that the `Claude Code Review` check now actually runs and posts a review comment, instead of failing before any job starts