### PR TITLE
fix(openclip): reject bootstrap option values with surrounding whitespace

### DIFF
--- a/embeddings/openclip/bootstrap.go
+++ b/embeddings/openclip/bootstrap.go
@@ -345,7 +345,7 @@ func ensureHTTPClientSecurity(cfg *bootstrapConfig) error {
 		return nil
 	}
 
-	requireHTTPS := strings.TrimSpace(cfg.hfToken) != ""
+	requireHTTPS := cfg.hfToken != ""
 	baseHost, err := parseBootstrapBaseHost(cfg.baseURL, requireHTTPS)
 	if err != nil {
 		return err
@@ -441,7 +441,7 @@ func ensureModelAssets(cfg bootstrapConfig) (ModelAssets, error) {
 	if cfg.maxDownloadBytes <= 0 {
 		return ModelAssets{}, fmt.Errorf("max download bytes must be > 0, got %d", cfg.maxDownloadBytes)
 	}
-	requireHTTPS := strings.TrimSpace(cfg.hfToken) != ""
+	requireHTTPS := cfg.hfToken != ""
 	baseHost, err := parseBootstrapBaseHost(cfg.baseURL, requireHTTPS)
 	if err != nil {
 		return ModelAssets{}, err
@@ -692,8 +692,10 @@ func downloadFileOnce(client *http.Client, assetURL string, destinationPath stri
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(hfToken) != "" {
-		req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(hfToken))
+	// hfToken carries no surrounding whitespace by construction: WithBootstrapToken
+	// rejects padded values and the HF_TOKEN fallback is trimmed at config time.
+	if hfToken != "" {
+		req.Header.Set("Authorization", "Bearer "+hfToken)
 	}
 
 	resp, err := client.Do(req)

--- a/embeddings/openclip/bootstrap.go
+++ b/embeddings/openclip/bootstrap.go
@@ -179,12 +179,13 @@ func WithBootstrapToken(token string) BootstrapOption {
 
 // WithBootstrapChecksum pins a SHA256 checksum for a required artifact.
 // The checksum is rejected if it is empty or carries leading/trailing whitespace.
+// All rejection messages name fileName, since callers typically pin several assets.
 func WithBootstrapChecksum(fileName string, checksum string) BootstrapOption {
 	return func(cfg *bootstrapConfig) error {
 		if err := validateAssetFileName(fileName); err != nil {
 			return err
 		}
-		if err := validateBootstrapField(checksum, "bootstrap checksum"); err != nil {
+		if err := validateBootstrapField(checksum, fmt.Sprintf("checksum for %s", fileName)); err != nil {
 			return err
 		}
 		normalized := strings.ToLower(checksum)
@@ -265,12 +266,16 @@ func defaultBootstrapConfig() (bootstrapConfig, error) {
 		cacheDir = filepath.Join(userCacheDir, "onnx-purego", "openclip")
 	}
 
+	// Trimmed rather than rejected: env padding is outside the caller's control,
+	// unlike a value passed to WithBootstrapToken.
+	hfToken := strings.TrimSpace(os.Getenv("HF_TOKEN"))
+
 	return bootstrapConfig{
 		repoID:             DefaultBootstrapRepoID,
 		revision:           DefaultBootstrapRevision,
 		baseURL:            DefaultBootstrapBaseURL,
 		cacheDir:           cacheDir,
-		hfToken:            strings.TrimSpace(os.Getenv("HF_TOKEN")),
+		hfToken:            hfToken,
 		verifySHA:          true,
 		shaByFile:          map[string]string{},
 		expectedSizeByFile: map[string]int64{},
@@ -599,6 +604,8 @@ func validateBootstrapField(value string, field string) error {
 // validateOptionalBootstrapField is validateBootstrapField for fields where an
 // empty value is meaningful ("unset") rather than an error. A whitespace-only
 // value is still rejected, since it is ambiguous rather than a deliberate unset.
+// The rejected value is never echoed: this guards credentials, and errors reach
+// logs and error trackers.
 func validateOptionalBootstrapField(value string, field string) error {
 	if value == "" {
 		return nil
@@ -608,7 +615,7 @@ func validateOptionalBootstrapField(value string, field string) error {
 		return fmt.Errorf("invalid %s: whitespace-only value is not allowed", field)
 	}
 	if trimmed != value {
-		return fmt.Errorf("invalid %s %q: leading or trailing whitespace is not allowed", field, value)
+		return fmt.Errorf("invalid %s: leading or trailing whitespace is not allowed", field)
 	}
 	return nil
 }

--- a/embeddings/openclip/bootstrap.go
+++ b/embeddings/openclip/bootstrap.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 )
 
 const (
@@ -135,11 +136,15 @@ func WithBootstrapCacheDir(path string) BootstrapOption {
 }
 
 // WithBootstrapRepoID sets the Hugging Face repo ID to fetch assets from.
-// The repo ID is rejected if it is empty or carries leading/trailing whitespace.
+// The repo ID is rejected if it is empty or contains any whitespace: unlike
+// revisions, Hugging Face repo IDs never legitimately contain spaces.
 func WithBootstrapRepoID(repoID string) BootstrapOption {
 	return func(cfg *bootstrapConfig) error {
 		if err := validateBootstrapField(repoID, "bootstrap repo ID"); err != nil {
 			return err
+		}
+		if strings.IndexFunc(repoID, unicode.IsSpace) != -1 {
+			return fmt.Errorf("invalid bootstrap repo ID %q: whitespace is not allowed", repoID)
 		}
 		cfg.repoID = repoID
 		return nil
@@ -160,20 +165,29 @@ func WithBootstrapRevision(revision string) BootstrapOption {
 }
 
 // WithBootstrapToken sets an optional Hugging Face access token for downloads.
+// The token is rejected if it carries leading/trailing whitespace; an empty
+// token is valid and means "no token".
 func WithBootstrapToken(token string) BootstrapOption {
 	return func(cfg *bootstrapConfig) error {
-		cfg.hfToken = strings.TrimSpace(token)
+		if err := validateOptionalBootstrapField(token, "bootstrap token"); err != nil {
+			return err
+		}
+		cfg.hfToken = token
 		return nil
 	}
 }
 
 // WithBootstrapChecksum pins a SHA256 checksum for a required artifact.
+// The checksum is rejected if it is empty or carries leading/trailing whitespace.
 func WithBootstrapChecksum(fileName string, checksum string) BootstrapOption {
 	return func(cfg *bootstrapConfig) error {
 		if err := validateAssetFileName(fileName); err != nil {
 			return err
 		}
-		normalized := strings.ToLower(strings.TrimSpace(checksum))
+		if err := validateBootstrapField(checksum, "bootstrap checksum"); err != nil {
+			return err
+		}
+		normalized := strings.ToLower(checksum)
 		if err := validateSHA256(normalized); err != nil {
 			return fmt.Errorf("invalid checksum for %s: %w", fileName, err)
 		}
@@ -582,10 +596,27 @@ func validateBootstrapField(value string, field string) error {
 	return nil
 }
 
+// validateOptionalBootstrapField is validateBootstrapField for fields where an
+// empty value is meaningful ("unset") rather than an error. A whitespace-only
+// value is still rejected, since it is ambiguous rather than a deliberate unset.
+func validateOptionalBootstrapField(value string, field string) error {
+	if value == "" {
+		return nil
+	}
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fmt.Errorf("invalid %s: whitespace-only value is not allowed", field)
+	}
+	if trimmed != value {
+		return fmt.Errorf("invalid %s %q: leading or trailing whitespace is not allowed", field, value)
+	}
+	return nil
+}
+
 func sanitizeBootstrapPathComponent(value string, field string) (string, error) {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
-		return "", fmt.Errorf("%s cannot be empty", strings.ToLower(field))
+		return "", fmt.Errorf("%s cannot be empty", field)
 	}
 
 	for _, segment := range strings.FieldsFunc(trimmed, func(r rune) bool {

--- a/embeddings/openclip/bootstrap.go
+++ b/embeddings/openclip/bootstrap.go
@@ -123,10 +123,11 @@ func (l *fileLock) Release() error {
 }
 
 // WithBootstrapCacheDir sets the local cache directory used for downloaded assets.
+// The path is rejected if it is empty or carries leading/trailing whitespace.
 func WithBootstrapCacheDir(path string) BootstrapOption {
 	return func(cfg *bootstrapConfig) error {
-		if strings.TrimSpace(path) == "" {
-			return fmt.Errorf("bootstrap cache directory cannot be empty")
+		if err := validateBootstrapField(path, "bootstrap cache directory"); err != nil {
+			return err
 		}
 		cfg.cacheDir = path
 		return nil
@@ -134,10 +135,11 @@ func WithBootstrapCacheDir(path string) BootstrapOption {
 }
 
 // WithBootstrapRepoID sets the Hugging Face repo ID to fetch assets from.
+// The repo ID is rejected if it is empty or carries leading/trailing whitespace.
 func WithBootstrapRepoID(repoID string) BootstrapOption {
 	return func(cfg *bootstrapConfig) error {
-		if strings.TrimSpace(repoID) == "" {
-			return fmt.Errorf("bootstrap repo ID cannot be empty")
+		if err := validateBootstrapField(repoID, "bootstrap repo ID"); err != nil {
+			return err
 		}
 		cfg.repoID = repoID
 		return nil
@@ -145,10 +147,12 @@ func WithBootstrapRepoID(repoID string) BootstrapOption {
 }
 
 // WithBootstrapRevision sets the Hugging Face revision to fetch assets from.
+// The revision is rejected if it is empty or carries leading/trailing whitespace.
+// Interior whitespace is permitted, since branch names may contain spaces.
 func WithBootstrapRevision(revision string) BootstrapOption {
 	return func(cfg *bootstrapConfig) error {
-		if strings.TrimSpace(revision) == "" {
-			return fmt.Errorf("bootstrap revision cannot be empty")
+		if err := validateBootstrapField(revision, "bootstrap revision"); err != nil {
+			return err
 		}
 		cfg.revision = revision
 		return nil
@@ -562,6 +566,20 @@ func escapeRepoIDForURL(repoID string) string {
 		repoSegments[i] = url.PathEscape(segment)
 	}
 	return strings.Join(repoSegments, "/")
+}
+
+// validateBootstrapField rejects option values that are empty or that carry
+// leading/trailing whitespace, so a value that passes validation is stored verbatim.
+// Interior whitespace is allowed: revisions may legitimately contain spaces.
+func validateBootstrapField(value string, field string) error {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return fmt.Errorf("%s cannot be empty", field)
+	}
+	if trimmed != value {
+		return fmt.Errorf("invalid %s %q: leading or trailing whitespace is not allowed", field, value)
+	}
+	return nil
 }
 
 func sanitizeBootstrapPathComponent(value string, field string) (string, error) {

--- a/embeddings/openclip/bootstrap_test.go
+++ b/embeddings/openclip/bootstrap_test.go
@@ -680,3 +680,66 @@ func sha256Hex(data []byte) string {
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:])
 }
+
+func TestBootstrapOptionsRejectSurroundingWhitespace(t *testing.T) {
+	cases := []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{name: "empty", value: "", wantErr: "cannot be empty"},
+		{name: "only whitespace", value: "   ", wantErr: "cannot be empty"},
+		{name: "leading space", value: " value", wantErr: "whitespace"},
+		{name: "trailing space", value: "value ", wantErr: "whitespace"},
+		{name: "trailing tab", value: "value\t", wantErr: "whitespace"},
+		{name: "leading newline", value: "\nvalue", wantErr: "whitespace"},
+	}
+
+	options := map[string]func(string) BootstrapOption{
+		"WithBootstrapCacheDir": WithBootstrapCacheDir,
+		"WithBootstrapRepoID":   WithBootstrapRepoID,
+		"WithBootstrapRevision": WithBootstrapRevision,
+	}
+
+	for optName, optFn := range options {
+		for _, tc := range cases {
+			t.Run(optName+"/"+tc.name, func(t *testing.T) {
+				var cfg bootstrapConfig
+				err := optFn(tc.value)(&cfg)
+				if err == nil {
+					t.Fatalf("expected rejection for %q", tc.value)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+				}
+			})
+		}
+	}
+}
+
+// Values that pass validation must be stored verbatim, and interior whitespace
+// stays legal because Hugging Face branch names may contain spaces.
+func TestBootstrapOptionsStoreAcceptedValuesVerbatim(t *testing.T) {
+	var cfg bootstrapConfig
+
+	if err := WithBootstrapCacheDir("/tmp/openclip cache")(&cfg); err != nil {
+		t.Fatalf("expected interior space to be accepted, got: %v", err)
+	}
+	if cfg.cacheDir != "/tmp/openclip cache" {
+		t.Fatalf("expected cache dir stored verbatim, got %q", cfg.cacheDir)
+	}
+
+	if err := WithBootstrapRepoID("owner/repo")(&cfg); err != nil {
+		t.Fatalf("expected repo ID to be accepted, got: %v", err)
+	}
+	if cfg.repoID != "owner/repo" {
+		t.Fatalf("expected repo ID stored verbatim, got %q", cfg.repoID)
+	}
+
+	if err := WithBootstrapRevision("branch/with space")(&cfg); err != nil {
+		t.Fatalf("expected interior space in revision to be accepted, got: %v", err)
+	}
+	if cfg.revision != "branch/with space" {
+		t.Fatalf("expected revision stored verbatim, got %q", cfg.revision)
+	}
+}

--- a/embeddings/openclip/bootstrap_test.go
+++ b/embeddings/openclip/bootstrap_test.go
@@ -757,11 +757,17 @@ func TestBootstrapOptionsTokenAndChecksumRejectPadding(t *testing.T) {
 		}
 	})
 
-	t.Run("token rejects padding", func(t *testing.T) {
+	// The rejection must not echo the token: errors routinely reach logs and
+	// error trackers, and a trailing newline on a real credential is common.
+	t.Run("token rejects padding without echoing the value", func(t *testing.T) {
+		const secret = "hf_SentinelTokenValue"
 		var cfg bootstrapConfig
-		err := WithBootstrapToken(" tok ")(&cfg)
+		err := WithBootstrapToken(" " + secret + "\n")(&cfg)
 		if err == nil || !strings.Contains(err.Error(), "whitespace") {
 			t.Fatalf("expected whitespace rejection, got: %v", err)
+		}
+		if strings.Contains(err.Error(), secret) {
+			t.Fatalf("token value leaked into error: %q", err.Error())
 		}
 	})
 
@@ -782,6 +788,24 @@ func TestBootstrapOptionsTokenAndChecksumRejectPadding(t *testing.T) {
 		err := WithBootstrapChecksum(textModelFileName, " "+validChecksum+" ")(&cfg)
 		if err == nil || !strings.Contains(err.Error(), "whitespace") {
 			t.Fatalf("expected whitespace rejection, got: %v", err)
+		}
+	})
+
+	// Callers pin several assets at once, so every rejection must say which one.
+	t.Run("checksum rejections name the file", func(t *testing.T) {
+		for _, tc := range []struct{ name, checksum string }{
+			{name: "empty", checksum: ""},
+			{name: "padded", checksum: " " + validChecksum + " "},
+			{name: "not hex", checksum: strings.Repeat("z", 64)},
+			{name: "wrong length", checksum: "abc123"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				cfg := bootstrapConfig{shaByFile: map[string]string{}}
+				err := WithBootstrapChecksum(textModelFileName, tc.checksum)(&cfg)
+				if err == nil || !strings.Contains(err.Error(), textModelFileName) {
+					t.Fatalf("expected error naming %s, got: %v", textModelFileName, err)
+				}
+			})
 		}
 	})
 

--- a/embeddings/openclip/bootstrap_test.go
+++ b/embeddings/openclip/bootstrap_test.go
@@ -695,26 +695,105 @@ func TestBootstrapOptionsRejectSurroundingWhitespace(t *testing.T) {
 		{name: "leading newline", value: "\nvalue", wantErr: "whitespace"},
 	}
 
-	options := map[string]func(string) BootstrapOption{
-		"WithBootstrapCacheDir": WithBootstrapCacheDir,
-		"WithBootstrapRepoID":   WithBootstrapRepoID,
-		"WithBootstrapRevision": WithBootstrapRevision,
+	options := []struct {
+		name      string
+		fn        func(string) BootstrapOption
+		wantField string
+	}{
+		{name: "WithBootstrapCacheDir", fn: WithBootstrapCacheDir, wantField: "bootstrap cache directory"},
+		{name: "WithBootstrapRepoID", fn: WithBootstrapRepoID, wantField: "bootstrap repo ID"},
+		{name: "WithBootstrapRevision", fn: WithBootstrapRevision, wantField: "bootstrap revision"},
 	}
 
-	for optName, optFn := range options {
+	for _, opt := range options {
 		for _, tc := range cases {
-			t.Run(optName+"/"+tc.name, func(t *testing.T) {
+			t.Run(opt.name+"/"+tc.name, func(t *testing.T) {
 				var cfg bootstrapConfig
-				err := optFn(tc.value)(&cfg)
+				err := opt.fn(tc.value)(&cfg)
 				if err == nil {
 					t.Fatalf("expected rejection for %q", tc.value)
 				}
 				if !strings.Contains(err.Error(), tc.wantErr) {
 					t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
 				}
+				// Guards against a copy/paste mix-up of the field argument between constructors.
+				if !strings.Contains(err.Error(), opt.wantField) {
+					t.Fatalf("expected error to name field %q, got: %v", opt.wantField, err)
+				}
 			})
 		}
 	}
+}
+
+// WithBootstrapRepoID is stricter than the shared whitespace validator: unlike
+// revisions, Hugging Face repo IDs never legitimately contain interior spaces.
+func TestBootstrapOptionsRepoIDRejectsInteriorWhitespace(t *testing.T) {
+	var cfg bootstrapConfig
+	err := WithBootstrapRepoID("owner/repo name")(&cfg)
+	if err == nil || !strings.Contains(err.Error(), "whitespace") {
+		t.Fatalf("expected interior whitespace in repo ID to be rejected, got: %v", err)
+	}
+}
+
+// WithBootstrapToken and WithBootstrapChecksum used to silently strings.TrimSpace
+// padded values; they now reject padding for the same reason the other bootstrap
+// options do, while still allowing an explicitly empty (unset) token.
+func TestBootstrapOptionsTokenAndChecksumRejectPadding(t *testing.T) {
+	t.Run("token accepts empty as unset", func(t *testing.T) {
+		var cfg bootstrapConfig
+		if err := WithBootstrapToken("")(&cfg); err != nil {
+			t.Fatalf("expected empty token to be accepted, got: %v", err)
+		}
+		if cfg.hfToken != "" {
+			t.Fatalf("expected empty token stored, got %q", cfg.hfToken)
+		}
+	})
+
+	t.Run("token rejects whitespace-only", func(t *testing.T) {
+		var cfg bootstrapConfig
+		err := WithBootstrapToken("   ")(&cfg)
+		if err == nil || !strings.Contains(err.Error(), "whitespace-only") {
+			t.Fatalf("expected whitespace-only rejection, got: %v", err)
+		}
+	})
+
+	t.Run("token rejects padding", func(t *testing.T) {
+		var cfg bootstrapConfig
+		err := WithBootstrapToken(" tok ")(&cfg)
+		if err == nil || !strings.Contains(err.Error(), "whitespace") {
+			t.Fatalf("expected whitespace rejection, got: %v", err)
+		}
+	})
+
+	t.Run("token stores verbatim", func(t *testing.T) {
+		var cfg bootstrapConfig
+		if err := WithBootstrapToken("hf_abc123")(&cfg); err != nil {
+			t.Fatalf("expected token to be accepted, got: %v", err)
+		}
+		if cfg.hfToken != "hf_abc123" {
+			t.Fatalf("expected token stored verbatim, got %q", cfg.hfToken)
+		}
+	})
+
+	validChecksum := sha256Hex([]byte("checksum-fixture"))
+
+	t.Run("checksum rejects padding", func(t *testing.T) {
+		cfg := bootstrapConfig{shaByFile: map[string]string{}}
+		err := WithBootstrapChecksum(textModelFileName, " "+validChecksum+" ")(&cfg)
+		if err == nil || !strings.Contains(err.Error(), "whitespace") {
+			t.Fatalf("expected whitespace rejection, got: %v", err)
+		}
+	})
+
+	t.Run("checksum accepts and normalizes case", func(t *testing.T) {
+		cfg := bootstrapConfig{shaByFile: map[string]string{}}
+		if err := WithBootstrapChecksum(textModelFileName, strings.ToUpper(validChecksum))(&cfg); err != nil {
+			t.Fatalf("expected checksum to be accepted, got: %v", err)
+		}
+		if cfg.shaByFile[textModelFileName] != validChecksum {
+			t.Fatalf("expected checksum normalized to lowercase, got %q", cfg.shaByFile[textModelFileName])
+		}
+	})
 }
 
 // Values that pass validation must be stored verbatim, and interior whitespace


### PR DESCRIPTION
Follow-up to #112, which deferred this deliberately: it is a behavior change, not a race, so it was kept out of the concurrency fix.

## Problem

Three OpenCLIP bootstrap options validated a *trimmed* value but stored the *raw* one:

| Constructor | Guard | Stored |
|---|---|---|
| `WithBootstrapCacheDir` | `strings.TrimSpace(path) == ""` | `path` |
| `WithBootstrapRepoID` | `strings.TrimSpace(repoID) == ""` | `repoID` |
| `WithBootstrapRevision` | `strings.TrimSpace(revision) == ""` | `revision` |

A padded value therefore passed validation and reached path and URL construction with the whitespace still attached. For `repoID` this matters beyond cosmetics: it is interpolated into a Hugging Face download URL via `escapeRepoIDForURL`, so `"owner/repo "` would resolve to a working but different download than the caller wrote.

The remaining two options, `WithBootstrapToken` and `WithBootstrapChecksum`, were inconsistent in the other direction: they silently `strings.TrimSpace`d before storing, quietly rewriting what the caller passed.

## Approach

Reject rather than silently normalize, so the mistake surfaces at option-application time instead of being quietly rewritten. A shared `validateBootstrapField` trims first, then classifies:

- empty or all-whitespace, keeps the existing `"<field> cannot be empty"` wording
- otherwise padded, new `invalid <field> "...": leading or trailing whitespace is not allowed`, following the `sanitizeBootstrapPathComponent` idiom already in this file

Values that pass are stored verbatim. `validateOptionalBootstrapField` is the same check for `WithBootstrapToken`, where empty means "unset" rather than an error; a whitespace-only token is still rejected as ambiguous.

**Interior whitespace stays legal for revisions.** Hugging Face branch names may contain spaces, and `TestEnsureModelAssetsEscapesRepoIDAndRevisionInURL` exercises `revision = "branch/with space"`. Validation is surrounding-only.

**Repo IDs are stricter.** `WithBootstrapRepoID` rejects *any* whitespace, interior included, since Hugging Face repo IDs never legitimately contain spaces and the value lands in a download URL.

## Secret handling

`validateOptionalBootstrapField` guards only the HF token, so it never echoes the rejected value. A padded credential — a trailing newline picked up from an env file or `cat` is the common case — would otherwise be returned verbatim inside an `error`, where it can reach logs, CI output, and error trackers. The field name alone identifies which option was misused:

```
invalid bootstrap token: leading or trailing whitespace is not allowed
```

`HF_TOKEN` read from the environment is still trimmed rather than rejected, and this is deliberate: that padding is outside the caller's control, unlike a value passed explicitly to `WithBootstrapToken`. The asymmetry is documented at the call site.

## Error messages

All four `WithBootstrapChecksum` rejection paths name the asset, since callers typically pin several at once and "bootstrap checksum cannot be empty" gives no indication which of the four it was:

```
checksum for text_model.onnx cannot be empty
invalid checksum for vision_model.onnx "...": leading or trailing whitespace is not allowed
invalid checksum for tokenizer.json: checksum must be 64 hex chars, got 6
```

`sanitizeBootstrapPathComponent` also had two spellings of its own field name — `strings.ToLower(field)` on the empty branch, raw `field` on the traversal branch. Both now use `field`. The empty branch is unreachable through the public API, since the defaults are non-empty constants and the options reject empty.

## Compatibility

Callers passing whitespace-padded values now get an error where they previously got silent acceptance or silent trimming. No in-repo caller does this.

Error text changes, for anyone matching on it:

- `cannot be empty` is unchanged for cache dir, repo ID, and revision
- empty checksums change from `invalid checksum for <file>: checksum must be 64 hex chars, got 0` to `checksum for <file> cannot be empty`
- padded tokens and checksums are new errors; these inputs previously succeeded

## Verification

- `TestBootstrapOptionsRejectSurroundingWhitespace` — 6 cases x 3 constructors (empty, all-whitespace, leading/trailing space, trailing tab, leading newline)
- `TestBootstrapOptionsRepoIDRejectsInteriorWhitespace` — interior whitespace rejected for repo IDs but not revisions
- `TestBootstrapOptionsTokenAndChecksumRejectPadding` — empty token accepted as unset, whitespace-only rejected, padded rejected **without the token appearing in the error**, and all four checksum rejection paths asserted to name the file
- `TestBootstrapOptionsStoreAcceptedValuesVerbatim` — accepted values stored unmodified, interior spaces accepted
- Fail-by-deletion checked on the original commit: removing the padding branch fails exactly 12 subtests while the 6 empty cases still pass, confirming both branches are independently load-bearing
- `go build ./...`, `gofmt`, and full `go test ./...` all green
- `golangci-lint run --new-from-merge-base=origin/main ./...` — 0 issues, matching the CI PR lane; the repo's pre-existing lint debt is untouched

The deferred-items entry tracking this lives on the #112 branch, so it is left untouched here and should be cleared once #112 merges.
